### PR TITLE
Use .sort_by instead of .order

### DIFF
--- a/app/controllers/plants_controller.rb
+++ b/app/controllers/plants_controller.rb
@@ -14,7 +14,7 @@ class PlantsController < ApplicationController
       end
     end
 
-    @plants = Plant.where(filter).order(week: :desc)
+    @plants = Plant.where(filter).sort_by(&:week).reverse
   end
 
   def show


### PR DESCRIPTION
active_hash had an issue raised which seems to relate to the bug in production where .order method breaks finder, returning the wrong record for the given parameters

https://github.com/active-hash/active_hash/issues/193