### PR TITLE
Let the quiz answerer know they're close to the right answer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,6 +40,7 @@ gem "bootsnap", require: false
 # gem "sassc-rails"
 
 gem "active_hash"
+gem "facets", require: false # So we don't load all the facets we don't need
 gem "humanize_boolean"
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,6 +82,7 @@ GEM
       irb (>= 1.5.0)
       reline (>= 0.3.1)
     erubi (1.12.0)
+    facets (3.1.0)
     globalid (1.0.0)
       activesupport (>= 5.0)
     humanize_boolean (0.0.2)
@@ -223,6 +224,7 @@ DEPENDENCIES
   bootsnap
   cssbundling-rails
   debug
+  facets
   humanize_boolean
   jsbundling-rails
   puma (~> 5.0)

--- a/app/controllers/plant_quiz_controller.rb
+++ b/app/controllers/plant_quiz_controller.rb
@@ -1,3 +1,5 @@
+require "facets/string/edit_distance"
+
 class PlantQuizController < ApplicationController
   module QuestionType
     TEXT = "text"
@@ -11,6 +13,12 @@ class PlantQuizController < ApplicationController
       TEXT
     end
     module_function :for_attribute
+  end
+
+  module Result
+    CORRECT = "correct"
+    NEARLY_CORRECT = "nearly correct"
+    INCORRECT = "incorrect"
   end
 
   QUESTION_COMBINATIONS = [
@@ -56,5 +64,13 @@ class PlantQuizController < ApplicationController
 
     @plant = Plant.find(plant_id)
     @expected_answer = @plant[@answer_attribute]
+
+    @result = if @given_answer == @expected_answer
+      Result::CORRECT
+    elsif @given_answer.edit_distance(@expected_answer) <= [@expected_answer.length / 3, 4].max
+      Result::NEARLY_CORRECT
+    else
+      Result::INCORRECT
+    end
   end
 end

--- a/app/views/plant_quiz/answer.turbo_stream.erb
+++ b/app/views/plant_quiz/answer.turbo_stream.erb
@@ -1,10 +1,17 @@
 <turbo-stream action="replace" target="result">
   <template>
     <div id="result">
-      <% if @given_answer == @expected_answer %>
+      <% case @result %>
+      <% when PlantQuizController::Result::CORRECT %>
         <p><strong>Correct!</strong></p>
-      <% else %>
-        <p><strong>Incorrect... Try again.</strong></p>
+      <% when PlantQuizController::Result::NEARLY_CORRECT %>
+        <p><strong>Nearly!</strong> Try again.</p>
+        <details>
+          <summary>The correct answer is...</summary>
+          <p class="<%= @answer_attribute %>"><%= @expected_answer %></p>
+        </details>
+      <% when PlantQuizController::Result::INCORRECT %>
+        <p><strong>Incorrect...</strong> Try again.</p>
         <details>
           <summary>The correct answer is...</summary>
           <p class="<%= @answer_attribute %>"><%= @expected_answer %></p>

--- a/app/views/plant_quiz/question.html.erb
+++ b/app/views/plant_quiz/question.html.erb
@@ -16,7 +16,7 @@
       </figure>
     <% end %>
   <% end %>
-  <%= form.text_field @answer_attribute, style: "font-style: italic" %>
+  <%= form.text_field @answer_attribute, class: @answer_attribute %>
 
   <%= form.submit "Am I right?" %>
 <% end %>


### PR DESCRIPTION
We use the Levenshtein distance (aka edit distance) between the two answers to judge how close they are.